### PR TITLE
Update .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,8 +1,11 @@
 builds:
-  - env:
+  # List of builds
+  - # First Build
+    env:
     - CGO_ENABLED=0
-  - main: main.go
-    binary: sensu-slack-handler
+    main: main.go
+    # Set the binary output location to bin/ so archive will comply with Sensu Go Asset structure
+    binary: bin/sensu-slack-handler
     goos:
       #-android
       - darwin


### PR DESCRIPTION
1. Fix syntax error cause goreleaser to see two builds instead of a single build. This was throwing errors in local testing.
2. update binary location to use bin/ directory in archive to match Sensu Asset structure

Addresses Issue #4 