### PR TITLE
Asset automation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,6 +46,11 @@ builds:
       - goos: linux
         goarch: mips64le
 
+checksum:
+  # You can change the name of the checksums file.
+  # Default is `{{ .ProjectName }}_{{ .Version }}_checksums.txt`.
+  name_template: "{{ .ProjectName }}_{{ .Version }}_sha256-checksums.txt"
+
 archive:
   format: tar.gz
   files:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ deploy:
 after_deploy:  
   - travis/generate-sha512sum.sh
   - cat "dist/sha512_file"
-  - travis/github-release-upload.sh github_api_token=$GITHUB_TOKEN repo_slug="$TRAVIS_REPO_SLUG" tag="${TRAVIS_TAG}" filename="$(cat dist/sha512_file)"
+  - travis/github-release-upload.sh github_api_token=$GITHUB_TOKEN repo_slug="$TRAVIS_REPO_SLUG" tag="${TRAVIS_TAG}" filename="dist/$(cat dist/sha512_file)"
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,17 @@ before_deploy:
 - go get github.com/goreleaser/goreleaser
 deploy:
   skip_cleanup: true
-  provider: script
-  script: goreleaser
-  on:
-    tags: true
+  - #goreleaser
+    provider: script
+    script: goreleaser
+    on:
+      tags: true
+  - #checksum
+    provider: script
+    script: travis/generate-sha512sum.sh
+    on:
+      tags: true
+
 env:
   global:
     secure: AAAAB3NzaC1yc2EAAAADAQABAAACAQDd8VD1c3Mno+WzqOC/4a59ersotUdAqOsQCdql8eVDlv49PWkFEUh/cKVmhnooGO68O+Qt3dcP7uqEo2DZtgxfTshd0JpT/IV6KLGqJbg8VWIbikY4AIlNZEov4PDjvGsyRogYfxbx5F71pr5TiYbvkyN4qYDZKJMmqfD1VcA5FYXrLg18SR3fuly+thfIQtD8yv9rHTMfk9KfcwoNbyLgmU28U6ZUHm0tz6x+UN9LT39oCSZAp3MvyLZvEmFZhyzSnfylhTzICi05F1gpPzD0CAvLHbtPGse7igXu1fupNEuM9f01g+uY/gsHNuxcgL026RcMd5EYvbr0F8chVrrZRTc7Emgd2QSqVGWZb0jVnIAF09FsIzHgt2nSQRkkEhNP80skOiDi3VthQ8b4XWO4hJ4bTm1C6DQGUN80Y8xtlNFYpHBA7GNV+zwIoTOGSb0vKP/786cVHx2E+hYZkP+03QXdv0zyeXevCS6s4TSKGyHv9apRg+6JZ1nGm6f1MPHB5OLEf582xi5RAkKtFGpKxDHyTv1KhcySzgOvbQTW488O2jPMUuTHAevp6HQvyOFe2OMYIyhu1xMK5rTBKzRMwMG8WH8Yf+9WqBJf2mmgqPuAX16KyXao9x/iyaFD9VnVyINqxxCO+LiTFGPvOU6uUNGm3Tm+HznOo7s13ueVEQ==

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
 
 before_script: 
 - echo "GITHUB TOKEN $GITHUB_TOKEN"
+- echo "REPO $TRAVIS_REPO_SLUG TAG ${TRAVIS_TAG}"
 
 before_deploy:
 - go get github.com/goreleaser/goreleaser

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,7 @@ deploy:
 after_deploy:  
   - travis/generate-sha512sum.sh
   - cat "dist/sha512_file"
-  - echo "dist/${sha512_file}"
-  - travis/github-release-upload.sh github_api_token=$GITHUB_TOKEN repo_slug="$TRAVIS_REPO_SLUG" tag="${TRAVIS_TAG}" filename="dist/${sha512_file}"
+  - travis/github-release-upload.sh github_api_token=$GITHUB_TOKEN repo_slug="$TRAVIS_REPO_SLUG" tag="${TRAVIS_TAG}" filename="$(cat dist/sha512_file)"
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ script:
   --enable=goconst --tests ./...
 
 before_script: 
-- echo "GITHUB TOKEN $GITHUB_TOKEN"
 - echo "REPO $TRAVIS_REPO_SLUG TAG ${TRAVIS_TAG}"
 
 before_deploy:
@@ -31,6 +30,7 @@ deploy:
 
 after_deploy:  
   - travis/generate-sha512sum.sh
+  - cat "dist/sha512_file"
   - echo "dist/${sha512_file}"
   - travis/github-release-upload.sh github_api_token=$GITHUB_TOKEN repo_slug="$TRAVIS_REPO_SLUG" tag="${TRAVIS_TAG}" filename="dist/${sha512_file}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: go
 go:
 - 1.10.x
+
+
 install:
 - go get gopkg.in/alecthomas/gometalinter.v1
 - go get github.com/gordonklaus/ineffassign
@@ -12,6 +14,10 @@ install:
 script:
 - gometalinter.v1 --vendor --disable-all --enable=vet --enable=golint --enable=ineffassign
   --enable=goconst --tests ./...
+
+before_script: 
+- echo "GITHUB TOKEN $GITHUB_TOKEN"
+
 before_deploy:
 - go get github.com/goreleaser/goreleaser
 deploy:
@@ -24,6 +30,8 @@ deploy:
 
 after_deploy:  
   - travis/generate-sha512sum.sh
+  - echo "dist/${sha512_file}"
+  - travis/github-release-upload.sh github_api_token=$GITHUB_TOKEN repo_slug="$TRAVIS_REPO_SLUG" tag="${TRAVIS_TAG}" filename="dist/${sha512_file}"
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,15 @@ script:
 before_deploy:
 - go get github.com/goreleaser/goreleaser
 deploy:
-  skip_cleanup: true
   - #goreleaser
     provider: script
     script: goreleaser
+    skip_cleanup: true
     on:
       tags: true
-  - #checksum
-    provider: script
-    script: travis/generate-sha512sum.sh
-    on:
-      tags: true
+
+after_deploy:  
+  - travis/generate-sha512sum.sh
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: go
 go:
 - 1.10.x
+
+
 install:
 - go get gopkg.in/alecthomas/gometalinter.v1
 - go get github.com/gordonklaus/ineffassign
@@ -12,20 +14,24 @@ install:
 script:
 - gometalinter.v1 --vendor --disable-all --enable=vet --enable=golint --enable=ineffassign
   --enable=goconst --tests ./...
+
+before_script: 
+- echo "REPO $TRAVIS_REPO_SLUG TAG ${TRAVIS_TAG}"
+
 before_deploy:
 - go get github.com/goreleaser/goreleaser
 deploy:
-  skip_cleanup: true
   - #goreleaser
     provider: script
     script: goreleaser
+    skip_cleanup: true
     on:
       tags: true
-  - #checksum
-    provider: script
-    script: travis/generate-sha512sum.sh
-    on:
-      tags: true
+
+after_deploy:  
+  - travis/generate-sha512sum.sh
+  - cat "dist/sha512_file"
+  - travis/github-release-upload.sh github_api_token=$GITHUB_TOKEN repo_slug="$TRAVIS_REPO_SLUG" tag="${TRAVIS_TAG}" filename="dist/$(cat dist/sha512_file)"
 
 env:
   global:

--- a/travis/generate-sha512sum.sh
+++ b/travis/generate-sha512sum.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+
+if [ -d dist ]; then
+  files=( dist/*sha256-checksums.txt )  
+  file=`basename ${files[0]}`
+  IFS=\_ read -r package prefix x <<< $file
+  if [ -n "$prefix" ]; then
+    echo "Generating sha512sum for ${package}_${prefix}"
+    cd dist
+    sha512sum *.tar.gz > "${package}_${prefix}_sha512-checksum.txt"
+    cat "${package}_${prefix}_sha512-checksum.txt"
+  fi
+fi

--- a/travis/generate-sha512sum.sh
+++ b/travis/generate-sha512sum.sh
@@ -2,19 +2,21 @@
 
 
 if [ -d dist ]; then
-  files=( dist/*sha256-checksums.txt )  
-  file=`basename ${files[0]}`
-  IFS=\_ read -r package prefix x <<< $file
+  files=( dist/*sha256-checksums.txt )
+  file=$(basename "${files[0]}")
+  IFS=_ read -r package prefix leftover <<< "$file"
+  unset leftover
   if [ -n "$prefix" ]; then
     echo "Generating sha512sum for ${package}_${prefix}"
-    cd dist
+    cd dist || exit
     sha512_file="${package}_${prefix}_sha512-checksums.txt"
     echo "${sha512_file}" > sha512_file
     echo "sha512_file: $(cat sha512_file)"
-    sha512sum *.tar.gz > "${sha512_file}"
+    sha512sum ./*.tar.gz > "${sha512_file}"
     echo ""
     cat "${sha512_file}"
   fi
 else
   echo "error"
 fi
+

--- a/travis/generate-sha512sum.sh
+++ b/travis/generate-sha512sum.sh
@@ -6,14 +6,11 @@ if [ -d dist ]; then
   file=`basename ${files[0]}`
   IFS=\_ read -r package prefix x <<< $file
   if [ -n "$prefix" ]; then
-    export package
-    export prefix
     echo "Generating sha512sum for ${package}_${prefix}"
     cd dist
-    sha512_file="${package}_${prefix}_sha512-checksum.txt"
-    export sha512_file
-    echo "sha512_file: ${sha512_file}"
+    sha512_file="${package}_${prefix}_sha512-checksums.txt"
     echo "${sha512_file}" > sha512_file
+    echo "sha512_file: $(cat sha512_file)"
     sha512sum *.tar.gz > "${sha512_file}"
     echo ""
     cat "${sha512_file}"

--- a/travis/generate-sha512sum.sh
+++ b/travis/generate-sha512sum.sh
@@ -8,7 +8,13 @@ if [ -d dist ]; then
   if [ -n "$prefix" ]; then
     echo "Generating sha512sum for ${package}_${prefix}"
     cd dist
-    sha512sum *.tar.gz > "${package}_${prefix}_sha512-checksum.txt"
-    cat "${package}_${prefix}_sha512-checksum.txt"
+    sha512_file="${package}_${prefix}_sha512-checksums.txt"
+    echo "${sha512_file}" > sha512_file
+    echo "sha512_file: $(cat sha512_file)"
+    sha512sum *.tar.gz > "${sha512_file}"
+    echo ""
+    cat "${sha512_file}"
   fi
+else
+  echo "error"
 fi

--- a/travis/generate-sha512sum.sh
+++ b/travis/generate-sha512sum.sh
@@ -10,9 +10,14 @@ if [ -d dist ]; then
     export prefix
     echo "Generating sha512sum for ${package}_${prefix}"
     cd dist
-    sha512sum *.tar.gz > "${package}_${prefix}_sha512-checksum.txt"
     sha512_file="${package}_${prefix}_sha512-checksum.txt"
     export sha512_file
-    cat "${sha512}"
+    echo "sha512_file: ${sha512_file}"
+    echo "${sha512_file}" > sha512_file
+    sha512sum *.tar.gz > "${sha512_file}"
+    echo ""
+    cat "${sha512_file}"
   fi
+else
+  echo "error"
 fi

--- a/travis/generate-sha512sum.sh
+++ b/travis/generate-sha512sum.sh
@@ -6,9 +6,13 @@ if [ -d dist ]; then
   file=`basename ${files[0]}`
   IFS=\_ read -r package prefix x <<< $file
   if [ -n "$prefix" ]; then
+    export package
+    export prefix
     echo "Generating sha512sum for ${package}_${prefix}"
     cd dist
     sha512sum *.tar.gz > "${package}_${prefix}_sha512-checksum.txt"
-    cat "${package}_${prefix}_sha512-checksum.txt"
+    sha512_file="${package}_${prefix}_sha512-checksum.txt"
+    export sha512_file
+    cat "${sha512}"
   fi
 fi

--- a/travis/github-release-upload.sh
+++ b/travis/github-release-upload.sh
@@ -23,7 +23,7 @@
 # Check dependencies.
 set -e
 
-# Set Meaninglist Defaults
+# Set Envvars Defaults:
 filename="text.txt"
 github_api_token="aaa"
 repo_slug="test/test"
@@ -35,6 +35,7 @@ id="0"
 
 CONFIG=( "$@" )
 
+# Update Envvars using cmdline args
 for line in "${CONFIG[@]}"; do
   eval "$line"
 done

--- a/travis/github-release-upload.sh
+++ b/travis/github-release-upload.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Author: Stefan Buck
+# License: MIT
+# https://gist.github.com/stefanbuck/ce788fee19ab6eb0b4447a85fc99f447
+#
+#
+# This script accepts the following parameters:
+#
+# * owner
+# * repo
+# * tag
+# * filename
+# * github_api_token
+#
+# Script to upload a release asset using the GitHub API v3.
+#
+# Example:
+#
+# upload-github-release-asset.sh github_api_token=TOKEN repo_slug=hey/now tag=v0.1.0 filename=./build.zip
+#
+
+# Check dependencies.
+set -e
+xargs=$(which xargs)
+
+# Validate settings.
+[ "$TRACE" ] && set -x
+
+CONFIG=$@
+
+for line in $CONFIG; do
+  eval "$line"
+done
+
+# Define variables.
+GH_API="https://api.github.com"
+GH_REPO="$GH_API/repos/$repo_slug"
+GH_TAGS="$GH_REPO/releases/tags/$tag"
+AUTH="Authorization: token $github_api_token"
+WGET_ARGS="--content-disposition --auth-no-challenge --no-cookie"
+CURL_ARGS="-LJO#"
+
+if [[ "$tag" == 'LATEST' ]]; then
+  GH_TAGS="$GH_REPO/releases/latest"
+fi
+
+# Validate token.
+curl -o /dev/null -sH "$AUTH" $GH_REPO || { echo "Error: Invalid repo, token or network issue!";  exit 1; }
+
+# Read asset tags.
+echo "curl -sH "$AUTH" $GH_TAGS"
+response=$(curl -sH "$AUTH" $GH_TAGS)
+
+# Get ID of the asset based on given filename.
+eval $(echo "$response" | grep -m 1 "id.:" | grep -w id | tr : = | tr -cd '[[:alnum:]]=')
+echo $id
+[ "$id" ] || { echo "Error: Failed to get release id for tag: $tag"; echo "$response" | awk 'length($0)<100' >&2; exit 1; }
+
+# Upload asset
+echo "Uploading asset... "
+
+# Construct url
+GH_ASSET="https://uploads.github.com/repos/$repo_slug/releases/$id/assets?name=$(basename $filename)"
+echo $GH_ASSET
+echo "curl $GITHUB_OAUTH_BASIC --data-binary @$filename -H \"Authorization: token $github_api_token\" -H \"Content-Type: application/octet-stream\" $GH_ASSET"
+curl ${GITHUB_OAUTH_BASIC} --data-binary @${filename} -H "Authorization: token ${github_api_token}" -H "Content-Type: application/octet-stream" ${GH_ASSET}

--- a/travis/github-release-upload.sh
+++ b/travis/github-release-upload.sh
@@ -17,19 +17,25 @@
 #
 # Example:
 #
-# upload-github-release-asset.sh github_api_token=TOKEN repo_slug=hey/now tag=v0.1.0 filename=./build.zip
+# github-release-upload.sh github_api_token=TOKEN repo_slug=hey/now tag=v0.1.0 filename=./build.zip
 #
 
 # Check dependencies.
 set -e
-xargs=$(which xargs)
+
+# Set Meaninglist Defaults
+filename="text.txt"
+github_api_token="aaa"
+repo_slug="test/test"
+tag="0.0.0"
+id="0"
 
 # Validate settings.
 [ "$TRACE" ] && set -x
 
-CONFIG=$@
+CONFIG=( "$@" )
 
-for line in $CONFIG; do
+for line in "${CONFIG[@]}"; do
   eval "$line"
 done
 
@@ -38,30 +44,32 @@ GH_API="https://api.github.com"
 GH_REPO="$GH_API/repos/$repo_slug"
 GH_TAGS="$GH_REPO/releases/tags/$tag"
 AUTH="Authorization: token $github_api_token"
-WGET_ARGS="--content-disposition --auth-no-challenge --no-cookie"
-CURL_ARGS="-LJO#"
 
 if [[ "$tag" == 'LATEST' ]]; then
   GH_TAGS="$GH_REPO/releases/latest"
 fi
 
 # Validate token.
-curl -o /dev/null -sH "$AUTH" $GH_REPO || { echo "Error: Invalid repo, token or network issue!";  exit 1; }
+curl -o /dev/null -sH "$AUTH" "$GH_REPO" || { echo "Error: Invalid repo, token or network issue!";  exit 1; }
 
 # Read asset tags.
-echo "curl -sH "$AUTH" $GH_TAGS"
-response=$(curl -sH "$AUTH" $GH_TAGS)
+echo "curl -sH ${AUTH} ${GH_TAGS}"
+response=$(curl -sH "${AUTH}" "${GH_TAGS}")
 
 # Get ID of the asset based on given filename.
-eval $(echo "$response" | grep -m 1 "id.:" | grep -w id | tr : = | tr -cd '[[:alnum:]]=')
-echo $id
+unset id
+eval "$(echo "$response" | grep -m 1 "id.:" | grep -w id | tr : = | tr -cd '[[:alnum:]]=')"
+echo "$id"
 [ "$id" ] || { echo "Error: Failed to get release id for tag: $tag"; echo "$response" | awk 'length($0)<100' >&2; exit 1; }
 
 # Upload asset
 echo "Uploading asset... "
 
 # Construct url
-GH_ASSET="https://uploads.github.com/repos/$repo_slug/releases/$id/assets?name=$(basename $filename)"
-echo $GH_ASSET
+GH_ASSET="https://uploads.github.com/repos/$repo_slug/releases/$id/assets?name=$(basename "$filename")"
+echo "$GH_ASSET"
 echo "curl $GITHUB_OAUTH_BASIC --data-binary @$filename -H \"Authorization: token $github_api_token\" -H \"Content-Type: application/octet-stream\" $GH_ASSET"
-curl ${GITHUB_OAUTH_BASIC} --data-binary @${filename} -H "Authorization: token ${github_api_token}" -H "Content-Type: application/octet-stream" ${GH_ASSET}
+curl "${GITHUB_OAUTH_BASIC}" --data-binary @"${filename}" -H "Authorization: token ${github_api_token}" -H "Content-Type: application/octet-stream" "${GH_ASSET}"
+
+
+


### PR DESCRIPTION
Add after_deploy travis automation to generate sha512 checksum file needed for Sensu asset config.

After_deploy actions:
1. generate sha512 checksum file based on existence of sha256 file 
2. upload sha512 checksum file into tagged release

Small adjustment to name of checksum file generated by goreleaser to indicate its sha256 checksums.

Closes https://github.com/sensu/sensu-slack-handler/issues/4