### PR TITLE
Feature/sensitive arguments as envvars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Use SLACK_WEBHOOK_URL envvar for default value of slack_webhook_url.  Use of envvar by default prevents leaking of sensitive credential into system process table via command argument. This is a backwards compatible change, and the --webhook-url argument can still be used as an override for testing purposes.
 
 ## [1.0.2] - 2018-12-04
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ slack-handler.json
         "type": "pipe",
         "command": "sensu-slack-handler --channel '#general' --timeout 20 --username 'sensu' ",
         "env_vars": [
-            "SLACK_WEBHOOK_URL='https://www.webhook-url-for-slack.com'"
+            "SLACK_WEBHOOK_URL=https://www.webhook-url-for-slack.com"
         ],
 
         "timeout": 30,

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Example Sensu Go check definition:
 }
 ```
 
-**Security Note:** The Slack webhook url is treated as a security sensitive configuration option in this example and is loaded into the handler config as an env_var instead of as a command argument. Command arguments are commonaly readable from the process table by other unprivaledged users on a system (ex: `ps` and `top` commands), so it's a better practise to read in sensitive information via environment variables or configuration files on disk. The `--webhook-url` flag is provided as an override for testing purposes.
+**Security Note:** The Slack webhook url is treated as a security sensitive configuration option in this example and is loaded into the handler config as an env_var instead of as a command argument. Command arguments are commonly readable from the process table by other unprivaledged users on a system (ex: `ps` and `top` commands), so it's a better practise to read in sensitive information via environment variables or configuration files on disk. The `--webhook-url` flag is provided as an override for testing purposes.
 
 ## Usage examples
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ go build -o /usr/local/bin/sensu-slack-handler main.go
 
 Example Sensu Go handler definition:
 
+
 slack-handler.json
 
 ```json
@@ -29,7 +30,11 @@ slack-handler.json
     },
     "spec": {
         "type": "pipe",
-        "command": "sensu-slack-handler --channel '#general' --timeout 20 --username 'sensu' --webhook-url 'https://www.webhook-url-for-slack.com'",
+        "command": "sensu-slack-handler --channel '#general' --timeout 20 --username 'sensu' ",
+        "env_vars": [
+            "SLACK_WEBHOOK_URL='https://www.webhook-url-for-slack.com'"
+        ],
+
         "timeout": 30,
         "filters": [
             "is_incident"
@@ -64,6 +69,8 @@ Example Sensu Go check definition:
 }
 ```
 
+**Security Note:** The Slack webhook url is treated as a security sensitive configuration option in this example and is loaded into the handler config as an env_var instead of as a command argument. Command arguments are commonaly readable from the process table by other unprivaledged users on a system (ex: `ps` and `top` commands), so it's a better practise to read in sensitive information via environment variables or configuration files on disk. The `--webhook-url` flag is provided as an override for testing purposes.
+
 ## Usage examples
 
 Help:
@@ -80,7 +87,7 @@ Flags:
   -i, --icon-url string      A URL to an image to use as the user avatar (default "http://s3-us-west-2.amazonaws.com/sensuapp.org/sensu.png")
   -t, --timeout int          The amount of seconds to wait before terminating the handler (default 10)
   -u, --username string      The username that messages will be sent as (default "sensu")
-  -w, --webhook-url string   The webhook url to send messages to
+  -w, --webhook-url string   The webhook url to send messages to, defaults to value of SLACK_WEBHOOK_URL env variable
 ```
 
 [1]: https://docs.sensu.io/sensu-go/5.0/reference/handlers/#how-do-sensu-handlers-work

--- a/main.go
+++ b/main.go
@@ -37,11 +37,17 @@ func configureRootCommand() *cobra.Command {
 		RunE:  run,
 	}
 
+	/*
+		Sensitive flags
+		default to using envvar value
+		do not mark as required
+		manually test for empty value
+	*/
 	cmd.Flags().StringVarP(&webhookURL,
 		"webhook-url",
 		"w",
-		"",
-		"The webhook url to send messages to")
+		os.Getenv("SLACK_WEBHOOK_URL"),
+		"The webhook url to send messages to, defaults to value of SLACK_WEBHOOK_URL env variable")
 
 	cmd.Flags().StringVarP(&channel,
 		"channel",
@@ -74,6 +80,11 @@ func run(cmd *cobra.Command, args []string) error {
 	if len(args) != 0 {
 		_ = cmd.Help()
 		return errors.New("invalid argument(s) received")
+	}
+	if webhookURL == "" {
+		_ = cmd.Help()
+		return fmt.Errorf("webhook url is empty")
+
 	}
 	if stdin == nil {
 		stdin = os.Stdin


### PR DESCRIPTION
Treat webhook as sensitive, default to taking value from SLACK_WEBHOOK_URL envvar