### PR TITLE
Add support for annotation-based configuration overrides. 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,1 @@
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-w -extldflags "-static"' -o sensu-slack-handler

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ var (
 	config 		= HandlerConfig{
 		// default values
 		Timeout: 10,
-		Keyspace: "sensu.io/integrations/slack/config",
+		Keyspace: "sensu.io/plugins/slack/config",
 	}
 )
 

--- a/main.go
+++ b/main.go
@@ -19,10 +19,10 @@ import (
 type HandlerConfig struct {
 	// A "Keyspace" field and corresponding "path" Field tags must be set to
 	// enable configuration overrides.
-	SlackWebhookUrl string `path:"webhook-url"`
-	SlackChannel string `path:"channel"`
-	SlackUsername string `path:"username"`
-	SlackIconUrl string `path:"icon-url"`
+	SlackWebhookUrl string `path:"webhook-url" env:"SENSU_SLACK_WEBHOOK_URL"`
+	SlackChannel string `path:"channel" env:"SENSU_SLACK_CHANNEL"`
+	SlackUsername string `path:"username" env:"SENSU_SLACK_USERNAME"`
+	SlackIconUrl string `path:"icon-url" env:"SENSU_SLACK_ICON_URL"`
 	Timeout int
 	Keyspace string
 }

--- a/main.go
+++ b/main.go
@@ -152,12 +152,12 @@ func configurationOverrides(c *HandlerConfig, event *types.Event) {
 				// compile the Annotation keyspace to look for configuration overrides
 				k := fmt.Sprintf("%s/%s",c.Keyspace,path)
 				switch {
-				case event.Entity.Annotations[k] != "":
-					overrideConfig(t.Field(i),&v,event.Entity.Annotations[k])
-					log.Printf("Overriding default handler configuration with value of \"Entity.Annotations.%s\" (\"%s\")\n",k,event.Entity.Annotations[k])
 				case event.Check.Annotations[k] != "":
 					overrideConfig(t.Field(i),&v,event.Check.Annotations[k])
 					log.Printf("Overriding default handler configuration with value of \"Check.Annotations.%s\" (\"%s\")\n",k,event.Check.Annotations[k])
+				case event.Entity.Annotations[k] != "":
+					overrideConfig(t.Field(i),&v,event.Entity.Annotations[k])
+					log.Printf("Overriding default handler configuration with value of \"Entity.Annotations.%s\" (\"%s\")\n",k,event.Entity.Annotations[k])
 				}
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"path"
 	"log"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/bluele/slack"
@@ -17,31 +17,31 @@ import (
 
 type HandlerConfigOption struct {
 	Value string
-	Path string
-	Env string
+	Path  string
+	Env   string
 }
 
 type HandlerConfig struct {
 	SlackWebhookUrl HandlerConfigOption
-	SlackChannel HandlerConfigOption
-	SlackUsername HandlerConfigOption
-	SlackIconUrl HandlerConfigOption
-	Timeout int
-	Keyspace string
+	SlackChannel    HandlerConfigOption
+	SlackUsername   HandlerConfigOption
+	SlackIconUrl    HandlerConfigOption
+	Timeout         int
+	Keyspace        string
 }
 
 var (
-	stdin     *os.File
-	config 		= HandlerConfig{
+	stdin  *os.File
+	config = HandlerConfig{
 		// default values
 		SlackWebhookUrl: HandlerConfigOption{Path: "webhook-url", Env: "SENSU_SLACK_WEHBOOK_URL"},
-		SlackChannel: HandlerConfigOption{Path: "channel", Env: "SENSU_SLACK_CHANNEL"},
-		SlackUsername: HandlerConfigOption{Path: "username", Env: "SENSU_SLACK_USERNAME"},
-		SlackIconUrl: HandlerConfigOption{Path: "icon-url", Env: "SENSU_SLACK_ICON_URL"},
-		Timeout: 10,
-		Keyspace: "sensu.io/plugins/slack/config",
+		SlackChannel:    HandlerConfigOption{Path: "channel", Env: "SENSU_SLACK_CHANNEL"},
+		SlackUsername:   HandlerConfigOption{Path: "username", Env: "SENSU_SLACK_USERNAME"},
+		SlackIconUrl:    HandlerConfigOption{Path: "icon-url", Env: "SENSU_SLACK_ICON_URL"},
+		Timeout:         10,
+		Keyspace:        "sensu.io/plugins/slack/config",
 	}
-	options 	= []*HandlerConfigOption{
+	options = []*HandlerConfigOption{
 		// iterable slice of user-overridable configuration options
 		&config.SlackWebhookUrl,
 		&config.SlackChannel,
@@ -53,7 +53,7 @@ var (
 func main() {
 	rootCmd := configureRootCommand()
 	if err := rootCmd.Execute(); err != nil {
-		log.Fatal(err.Error())
+		log.Fatal(err)
 	}
 }
 
@@ -123,13 +123,13 @@ func run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to unmarshal stdin data: %s", eventJSON)
 	}
 
-  // configuration validation & overrides
+	// configuration validation & overrides
 	if config.SlackWebhookUrl.Value == "" {
 		_ = cmd.Help()
 		return fmt.Errorf("webhook url is empty")
 	}
 
-	configurationOverrides(&config,options,event)
+	configurationOverrides(&config, options, event)
 
 	if err = validateEvent(event); err != nil {
 		return errors.New(err.Error())
@@ -146,17 +146,17 @@ func configurationOverrides(config *HandlerConfig, options []*HandlerConfigOptio
 	if config.Keyspace == "" {
 		return
 	}
-	for _,opt := range options {
+	for _, opt := range options {
 		if opt.Path != "" {
 			// compile the Annotation keyspace to look for configuration overrides
-			k := path.Join(config.Keyspace,opt.Path)
+			k := path.Join(config.Keyspace, opt.Path)
 			switch {
 			case event.Check.Annotations[k] != "":
 				opt.Value = event.Check.Annotations[k]
-				log.Printf("Overriding default handler configuration with value of \"Check.Annotations.%s\" (\"%s\")\n",k,event.Check.Annotations[k])
+				log.Printf("Overriding default handler configuration with value of \"Check.Annotations.%s\" (\"%s\")\n", k, event.Check.Annotations[k])
 			case event.Entity.Annotations[k] != "":
 				opt.Value = event.Entity.Annotations[k]
-				log.Printf("Overriding default handler configuration with value of \"Entity.Annotations.%s\" (\"%s\")\n",k,event.Entity.Annotations[k])
+				log.Printf("Overriding default handler configuration with value of \"Entity.Annotations.%s\" (\"%s\")\n", k, event.Entity.Annotations[k])
 			}
 		}
 	}
@@ -264,11 +264,11 @@ func validateEvent(event *types.Event) error {
 	}
 
 	if err := event.Entity.Validate(); err != nil {
-		log.Fatal(err.Error())
+		return err
 	}
 
 	if err := event.Check.Validate(); err != nil {
-		log.Fatal(err.Error())
+		return err
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -5,24 +5,27 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"path"
 	"log"
 	"os"
 	"strings"
-	"strconv"
-	"reflect"
 
 	"github.com/bluele/slack"
 	"github.com/sensu/sensu-go/types"
 	"github.com/spf13/cobra"
 )
 
+type HandlerConfigOption struct {
+	Value string
+	Path string
+	Env string
+}
+
 type HandlerConfig struct {
-	// A "Keyspace" field and corresponding "path" Field tags must be set to
-	// enable configuration overrides.
-	SlackWebhookUrl string `path:"webhook-url" env:"SENSU_SLACK_WEBHOOK_URL"`
-	SlackChannel string `path:"channel" env:"SENSU_SLACK_CHANNEL"`
-	SlackUsername string `path:"username" env:"SENSU_SLACK_USERNAME"`
-	SlackIconUrl string `path:"icon-url" env:"SENSU_SLACK_ICON_URL"`
+	SlackWebhookUrl HandlerConfigOption
+	SlackChannel HandlerConfigOption
+	SlackUsername HandlerConfigOption
+	SlackIconUrl HandlerConfigOption
 	Timeout int
 	Keyspace string
 }
@@ -31,8 +34,19 @@ var (
 	stdin     *os.File
 	config 		= HandlerConfig{
 		// default values
+		SlackWebhookUrl: HandlerConfigOption{Path: "webhook-url", Env: "SENSU_SLACK_WEHBOOK_URL"},
+		SlackChannel: HandlerConfigOption{Path: "channel", Env: "SENSU_SLACK_CHANNEL"},
+		SlackUsername: HandlerConfigOption{Path: "username", Env: "SENSU_SLACK_USERNAME"},
+		SlackIconUrl: HandlerConfigOption{Path: "icon-url", Env: "SENSU_SLACK_ICON_URL"},
 		Timeout: 10,
 		Keyspace: "sensu.io/plugins/slack/config",
+	}
+	options 	= []*HandlerConfigOption{
+		// iterable slice of user-overridable configuration options
+		&config.SlackWebhookUrl,
+		&config.SlackChannel,
+		&config.SlackUsername,
+		&config.SlackIconUrl,
 	}
 )
 
@@ -56,25 +70,25 @@ func configureRootCommand() *cobra.Command {
 		do not mark as required
 		manually test for empty value
 	*/
-	cmd.Flags().StringVarP(&config.SlackWebhookUrl,
+	cmd.Flags().StringVarP(&config.SlackWebhookUrl.Value,
 		"webhook-url",
 		"w",
 		os.Getenv("SLACK_WEBHOOK_URL"),
 		"The webhook url to send messages to, defaults to value of SLACK_WEBHOOK_URL env variable")
 
-	cmd.Flags().StringVarP(&config.SlackChannel,
+	cmd.Flags().StringVarP(&config.SlackChannel.Value,
 		"channel",
 		"c",
 		"#general",
 		"The channel to post messages to")
 
-	cmd.Flags().StringVarP(&config.SlackUsername,
+	cmd.Flags().StringVarP(&config.SlackUsername.Value,
 		"username",
 		"u",
 		"sensu",
 		"The username that messages will be sent as")
 
-	cmd.Flags().StringVarP(&config.SlackIconUrl,
+	cmd.Flags().StringVarP(&config.SlackIconUrl.Value,
 		"icon-url",
 		"i",
 		"http://s3-us-west-2.amazonaws.com/sensuapp.org/sensu.png",
@@ -110,12 +124,12 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
   // configuration validation & overrides
-	if config.SlackWebhookUrl == "" {
+	if config.SlackWebhookUrl.Value == "" {
 		_ = cmd.Help()
 		return fmt.Errorf("webhook url is empty")
 	}
 
-	configurationOverrides(&config,event)
+	configurationOverrides(&config,options,event)
 
 	if err = validateEvent(event); err != nil {
 		return errors.New(err.Error())
@@ -128,37 +142,21 @@ func run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func overrideConfig(t reflect.StructField, v *reflect.Value, o string) {
-	switch t.Type.Name() {
-		case "string":
-			v.FieldByName(t.Name).SetString(o)
-		case "int":
-			i,err := strconv.Atoi(o)
-			if err != nil {
-				log.Fatal(err)
-			}
-			v.FieldByName(t.Name).SetInt(int64(i))
+func configurationOverrides(config *HandlerConfig, options []*HandlerConfigOption, event *types.Event) {
+	if config.Keyspace == "" {
+		return
 	}
-}
-
-func configurationOverrides(c *HandlerConfig, event *types.Event) {
-	if c.Keyspace != "" {
-		// Use Golang reflection to dynamically walk the configuration object
-		t := reflect.TypeOf(HandlerConfig{})
-		v := reflect.ValueOf(c).Elem()
-		for i := 0; i < t.NumField(); i++ {
-			// For any field
-			if path := t.Field(i).Tag.Get("path"); path != "" {
-				// compile the Annotation keyspace to look for configuration overrides
-				k := fmt.Sprintf("%s/%s",c.Keyspace,path)
-				switch {
-				case event.Check.Annotations[k] != "":
-					overrideConfig(t.Field(i),&v,event.Check.Annotations[k])
-					log.Printf("Overriding default handler configuration with value of \"Check.Annotations.%s\" (\"%s\")\n",k,event.Check.Annotations[k])
-				case event.Entity.Annotations[k] != "":
-					overrideConfig(t.Field(i),&v,event.Entity.Annotations[k])
-					log.Printf("Overriding default handler configuration with value of \"Entity.Annotations.%s\" (\"%s\")\n",k,event.Entity.Annotations[k])
-				}
+	for _,opt := range options {
+		if opt.Path != "" {
+			// compile the Annotation keyspace to look for configuration overrides
+			k := path.Join(config.Keyspace,opt.Path)
+			switch {
+			case event.Check.Annotations[k] != "":
+				opt.Value = event.Check.Annotations[k]
+				log.Printf("Overriding default handler configuration with value of \"Check.Annotations.%s\" (\"%s\")\n",k,event.Check.Annotations[k])
+			case event.Entity.Annotations[k] != "":
+				opt.Value = event.Entity.Annotations[k]
+				log.Printf("Overriding default handler configuration with value of \"Entity.Annotations.%s\" (\"%s\")\n",k,event.Entity.Annotations[k])
 			}
 		}
 	}
@@ -243,12 +241,12 @@ func messageAttachment(event *types.Event) *slack.Attachment {
 }
 
 func sendMessage(event *types.Event) error {
-	hook := slack.NewWebHook(config.SlackWebhookUrl)
+	hook := slack.NewWebHook(config.SlackWebhookUrl.Value)
 	return hook.PostMessage(&slack.WebHookPostPayload{
 		Attachments: []*slack.Attachment{messageAttachment(event)},
-		Channel:     config.SlackChannel,
-		IconUrl:     config.SlackIconUrl,
-		Username:    config.SlackUsername,
+		Channel:     config.SlackChannel.Value,
+		IconUrl:     config.SlackIconUrl.Value,
+		Username:    config.SlackUsername.Value,
 	})
 }
 
@@ -266,11 +264,11 @@ func validateEvent(event *types.Event) error {
 	}
 
 	if err := event.Entity.Validate(); err != nil {
-		return err
+		log.Fatal(err.Error())
 	}
 
 	if err := event.Check.Validate(); err != nil {
-		return errors.New(err.Error())
+		log.Fatal(err.Error())
 	}
 
 	return nil

--- a/main_test.go
+++ b/main_test.go
@@ -116,8 +116,8 @@ func TestSendMessage(t *testing.T) {
 		require.NoError(t, err)
 	}))
 
-	webhookURL = apiStub.URL
-	channel = "#test"
+	config.SlackWebhookUrl.Value = apiStub.URL
+	config.SlackChannel.Value = "#test"
 	err := sendMessage(event)
 	assert.NoError(err)
 }

--- a/testing/data/example-event.json
+++ b/testing/data/example-event.json
@@ -182,8 +182,8 @@
         "foo": "bar"
       },
       "annotations": {
-        "sensu.io/integrations/slack/config/channel": "#demo-service-a",
-        "sensu.io/integrations/slack/config/username": "Sensu Go FTW!"        
+        "sensu.io/plugins/slack/config/channel": "#demo-service-a",
+        "sensu.io/plugins/slack/config/username": "Sensu Go FTW!"        
       }
     }
   },

--- a/testing/data/example-event.json
+++ b/testing/data/example-event.json
@@ -1,0 +1,193 @@
+{
+  "timestamp": 1548109478,
+  "entity": {
+    "entity_class": "agent",
+    "system": {
+      "hostname": "70faa7c58706",
+      "os": "linux",
+      "platform": "debian",
+      "platform_family": "debian",
+      "platform_version": "9.6",
+      "network": {
+        "interfaces": [
+          {
+            "name": "lo",
+            "addresses": [
+              "127.0.0.1/8"
+            ]
+          },
+          {
+            "name": "eth0",
+            "mac": "02:42:ac:15:00:07",
+            "addresses": [
+              "172.21.0.7/16"
+            ]
+          }
+        ]
+      },
+      "arch": "amd64"
+    },
+    "subscriptions": [
+      "linux",
+      "docker",
+      "poller",
+      "entity:70faa7c58706"
+    ],
+    "last_seen": 1548099786,
+    "deregister": true,
+    "deregistration": {},
+    "user": "agent",
+    "redact": [
+      "password",
+      "passwd",
+      "pass",
+      "api_key",
+      "api_token",
+      "access_key",
+      "secret_key",
+      "private_key",
+      "secret"
+    ],
+    "metadata": {
+      "name": "70faa7c58706",
+      "namespace": "default",
+      "labels": {
+        "region": "us-west-1"
+      }
+    }
+  },
+  "check": {
+    "command": "echo \"Hello linux world!\" && exit 1",
+    "handlers": [
+      "remediation"
+    ],
+    "high_flap_threshold": 0,
+    "interval": 10,
+    "low_flap_threshold": 0,
+    "publish": true,
+    "runtime_assets": null,
+    "subscriptions": [
+      "linux"
+    ],
+    "proxy_entity_name": "",
+    "check_hooks": null,
+    "stdin": false,
+    "subdue": null,
+    "ttl": 0,
+    "timeout": 0,
+    "round_robin": false,
+    "duration": 0.005119243,
+    "executed": 1548109478,
+    "history": [
+      {
+        "status": 1,
+        "executed": 1548109285
+      },
+      {
+        "status": 1,
+        "executed": 1548109295
+      },
+      {
+        "status": 1,
+        "executed": 1548109305
+      },
+      {
+        "status": 1,
+        "executed": 1548109315
+      },
+      {
+        "status": 1,
+        "executed": 1548109325
+      },
+      {
+        "status": 1,
+        "executed": 1548109335
+      },
+      {
+        "status": 1,
+        "executed": 1548109345
+      },
+      {
+        "status": 1,
+        "executed": 1548109355
+      },
+      {
+        "status": 1,
+        "executed": 1548109365
+      },
+      {
+        "status": 1,
+        "executed": 1548109375
+      },
+      {
+        "status": 1,
+        "executed": 1548109385
+      },
+      {
+        "status": 1,
+        "executed": 1548109395
+      },
+      {
+        "status": 1,
+        "executed": 1548109405
+      },
+      {
+        "status": 1,
+        "executed": 1548109415
+      },
+      {
+        "status": 1,
+        "executed": 1548109425
+      },
+      {
+        "status": 1,
+        "executed": 1548109435
+      },
+      {
+        "status": 1,
+        "executed": 1548109445
+      },
+      {
+        "status": 1,
+        "executed": 1548109455
+      },
+      {
+        "status": 1,
+        "executed": 1548109458
+      },
+      {
+        "status": 1,
+        "executed": 1548109468
+      },
+      {
+        "status": 1,
+        "executed": 1548109478
+      }
+    ],
+    "issued": 1548109478,
+    "output": "Hello linux world!\n",
+    "state": "failing",
+    "status": 1,
+    "total_state_change": 0,
+    "last_ok": 1548105266,
+    "occurrences": 423,
+    "occurrences_watermark": 423,
+    "output_metric_format": "",
+    "output_metric_handlers": null,
+    "env_vars": null,
+    "metadata": {
+      "name": "helloworld",
+      "namespace": "default",
+      "labels": {
+        "foo": "bar"
+      },
+      "annotations": {
+        "sensu.io/integrations/slack/config/channel": "#demo-service-a",
+        "sensu.io/integrations/slack/config/username": "Sensu Go FTW!"        
+      }
+    }
+  },
+  "metadata": {
+    "namespace": "default"
+  }
+}

--- a/testing/manifests/check.yaml
+++ b/testing/manifests/check.yaml
@@ -1,0 +1,22 @@
+---
+type: CheckConfig
+api_version: core/v2
+metadata:
+  name: helloworld
+  namespace: default
+  labels:
+    foo: bar
+  annotations:
+    senus.io/integrations/slack/config/webhook_url: nil
+    sensu.io/integrations/slack/config/channel: "#demo"
+    sensu.io/integrations/slack/config/username: SensuBot
+    sensu.io/integrations/slack/config/icon_url: nil
+    sensu.io/integrations/slack/config/timeout: 10
+spec:
+  command: echo "Hello {{ .system.os }} world!" && exit 1
+  publish: false
+  interval: 10
+  handlers:
+  - slack
+  subscriptions:
+  - development

--- a/testing/manifests/check.yaml
+++ b/testing/manifests/check.yaml
@@ -7,11 +7,7 @@ metadata:
   labels:
     foo: bar
   annotations:
-    senus.io/plugins/slack/config/webhook_url: nil
     sensu.io/plugins/slack/config/channel: "#demo"
-    sensu.io/plugins/slack/config/username: SensuBot
-    sensu.io/plugins/slack/config/icon_url: nil
-    sensu.io/plugins/slack/config/timeout: 10
 spec:
   command: echo "Hello {{ .system.os }} world!" && exit 1
   publish: false

--- a/testing/manifests/check.yaml
+++ b/testing/manifests/check.yaml
@@ -7,11 +7,11 @@ metadata:
   labels:
     foo: bar
   annotations:
-    senus.io/integrations/slack/config/webhook_url: nil
-    sensu.io/integrations/slack/config/channel: "#demo"
-    sensu.io/integrations/slack/config/username: SensuBot
-    sensu.io/integrations/slack/config/icon_url: nil
-    sensu.io/integrations/slack/config/timeout: 10
+    senus.io/plugins/slack/config/webhook_url: nil
+    sensu.io/plugins/slack/config/channel: "#demo"
+    sensu.io/plugins/slack/config/username: SensuBot
+    sensu.io/plugins/slack/config/icon_url: nil
+    sensu.io/plugins/slack/config/timeout: 10
 spec:
   command: echo "Hello {{ .system.os }} world!" && exit 1
   publish: false


### PR DESCRIPTION
This is my first PR of a Golang thing, and I'm still learning what are "best practices" in Golang, so please don't hesitate to point out obvious mistakes so I can learn! 🙏 

This PR implements proposed support for overriding the default handler config with settings provided as Entity or Check annotations. The real goal here is to identify a convention which we could promote as a standard across all Sensu- and Community-developed plugins. 

Given an example handler definition manifest: 

```yaml
---
api_version: core/v2
type: Handler
metadata:
  namespace: default
  name: slack
spec:
  type: pipe
  command: sensu-slack-handler --channel "#demo" --timeout 10 --username "SensuBot" --webhook-url https://hooks.slack.com/services/xxxxxxxxxx/xxxxxxxxxx/xxxxxxxxxx
  timeout: 10
  runtime_assets:
  - sensu-slack-handler
  filters:
  - is_incident
```

The following check definition could override the default configuration and cause the Slack notification to get posted in the `#demo-service-a` channel instead of the default `#demo` channel. 

```yaml
---
type: CheckConfig
api_version: core/v2
metadata:
  name: helloworld
  namespace: default
  labels:
    foo: bar
  annotations:
    sensu.io/plugins/slack/config/channel: "#demo-service-a"
spec:
  command: echo "Hello {{ .system.os }} world!" && exit 1
  publish: false
  interval: 10
  handlers:
  - slack
  subscriptions:
  - development
```

Let's discuss! 

/cc @portertech 
