### PR TITLE
Updating readme for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,68 +9,11 @@ a configured Slack channel.
 
 ### Asset registration
 
-Assets are the best way to make use of this handler. If you're not using an asset, please consider doing so! You can find this asset on the [Bonsai Asset Index](https://bonsai.sensu.io/assets/sensu/sensu-slack-handler).
+Assets are the best way to make use of this handler. If you're not using an asset, please consider doing so! If you're using sensuctl 5.13 or later, you can use the following command to add the asset: 
 
-#### Example asset definitions:
+`sensuctl asset add sensu/sensu-slack-handler:1.0.3`
 
-**sensu-slack-handler-asset.json**
-
-```json
-{
-  "type": "Asset",
-  "api_version": "core/v2",
-  "metadata": {
-    "name": "sensu-slack-handler_linux_amd64",
-    "labels": null,
-    "annotations": {
-      "io.sensu.bonsai.url": "https://bonsai.sensu.io/assets/sensu/sensu-slack-handler",
-      "io.sensu.bonsai.api_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-slack-handler",
-      "io.sensu.bonsai.tier": "Supported",
-      "io.sensu.bonsai.version": "1.0.3",
-      "io.sensu.bonsai.namespace": "sensu",
-      "io.sensu.bonsai.name": "sensu-slack-handler",
-      "io.sensu.bonsai.tags": ""
-    }
-  },
-  "spec": {
-    "url": "https://assets.bonsai.sensu.io/3149de09525d5e042a83edbb6eb46152b02b5a65/sensu-slack-handler_1.0.3_linux_amd64.tar.gz",
-    "sha512": "68720865127fbc7c2fe16ca4d7bbf2a187a2df703f4b4acae1c93e8a66556e9079e1270521999b5871473e6c851f51b34097c54fdb8d18eedb7064df9019adc8",
-    "filters": [
-      "entity.system.os == 'linux'",
-      "entity.system.arch == 'amd64'"
-    ]
-  }
-}
-```
-
-`sensuctl create -f sensu-slack-handler-asset.json`
-
-**sensu-slack-handler-asset.yml**
-
-```yaml
----
-type: Asset
-api_version: core/v2
-metadata:
-  name: sensu-slack-handler_linux_amd64
-  labels: 
-  annotations:
-    io.sensu.bonsai.url: https://bonsai.sensu.io/assets/sensu/sensu-slack-handler
-    io.sensu.bonsai.api_url: https://bonsai.sensu.io/api/v1/assets/sensu/sensu-slack-handler
-    io.sensu.bonsai.tier: Supported
-    io.sensu.bonsai.version: 1.0.3
-    io.sensu.bonsai.namespace: sensu
-    io.sensu.bonsai.name: sensu-slack-handler
-    io.sensu.bonsai.tags: ''
-spec:
-  url: https://assets.bonsai.sensu.io/3149de09525d5e042a83edbb6eb46152b02b5a65/sensu-slack-handler_1.0.3_linux_amd64.tar.gz
-  sha512: 68720865127fbc7c2fe16ca4d7bbf2a187a2df703f4b4acae1c93e8a66556e9079e1270521999b5871473e6c851f51b34097c54fdb8d18eedb7064df9019adc8
-  filters:
-  - entity.system.os == 'linux'
-  - entity.system.arch == 'amd64'
-```
-
-`sensuctl create -f sensu-slack-handler-asset.yml`
+If you're using an earlier version of sensuctl, you can find the asset on the [Bonsai Asset Index](https://bonsai.sensu.io/assets/sensu/sensu-slack-handler).
 
 #### Example Sensu Go handler definition:
 

--- a/README.md
+++ b/README.md
@@ -3,22 +3,76 @@
 The Sensu Slack handler is a [Sensu Event Handler][1] that sends event data to
 a configured Slack channel.
 
-## Installation
-
-Download the latest version of the sensu-slack-handler from [releases][2],
-or create an executable script from this source.
-
-From the local path of the slack-handler repository:
-```
-go build -o /usr/local/bin/sensu-slack-handler main.go
-```
-
 ## Configuration
 
-Example Sensu Go handler definition:
+### Asset registration
 
+Assets are the best way to make use of this handler. If you're not using an asset, please consider doing so! You can find this asset on the [Bonsai Asset Index](https://bonsai.sensu.io/assets/sensu/sensu-slack-handler).
 
-slack-handler.json
+#### Example asset definitions:
+
+**sensu-slack-handler-asset.json**
+
+```json
+{
+  "type": "Asset",
+  "api_version": "core/v2",
+  "metadata": {
+    "name": "sensu-slack-handler_linux_amd64",
+    "labels": null,
+    "annotations": {
+      "io.sensu.bonsai.url": "https://bonsai.sensu.io/assets/sensu/sensu-slack-handler",
+      "io.sensu.bonsai.api_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-slack-handler",
+      "io.sensu.bonsai.tier": "Supported",
+      "io.sensu.bonsai.version": "1.0.3",
+      "io.sensu.bonsai.namespace": "sensu",
+      "io.sensu.bonsai.name": "sensu-slack-handler",
+      "io.sensu.bonsai.tags": ""
+    }
+  },
+  "spec": {
+    "url": "https://assets.bonsai.sensu.io/3149de09525d5e042a83edbb6eb46152b02b5a65/sensu-slack-handler_1.0.3_linux_amd64.tar.gz",
+    "sha512": "68720865127fbc7c2fe16ca4d7bbf2a187a2df703f4b4acae1c93e8a66556e9079e1270521999b5871473e6c851f51b34097c54fdb8d18eedb7064df9019adc8",
+    "filters": [
+      "entity.system.os == 'linux'",
+      "entity.system.arch == 'amd64'"
+    ]
+  }
+}
+```
+
+`sensuctl create -f sensu-slack-handler-asset.json`
+
+**sensu-slack-handler-asset.yml**
+
+```yaml
+---
+type: Asset
+api_version: core/v2
+metadata:
+  name: sensu-slack-handler_linux_amd64
+  labels: 
+  annotations:
+    io.sensu.bonsai.url: https://bonsai.sensu.io/assets/sensu/sensu-slack-handler
+    io.sensu.bonsai.api_url: https://bonsai.sensu.io/api/v1/assets/sensu/sensu-slack-handler
+    io.sensu.bonsai.tier: Supported
+    io.sensu.bonsai.version: 1.0.3
+    io.sensu.bonsai.namespace: sensu
+    io.sensu.bonsai.name: sensu-slack-handler
+    io.sensu.bonsai.tags: ''
+spec:
+  url: https://assets.bonsai.sensu.io/3149de09525d5e042a83edbb6eb46152b02b5a65/sensu-slack-handler_1.0.3_linux_amd64.tar.gz
+  sha512: 68720865127fbc7c2fe16ca4d7bbf2a187a2df703f4b4acae1c93e8a66556e9079e1270521999b5871473e6c851f51b34097c54fdb8d18eedb7064df9019adc8
+  filters:
+  - entity.system.os == 'linux'
+  - entity.system.arch == 'amd64'
+```
+
+`sensuctl create -f sensu-slack-handler-asset.yml`
+
+#### Example Sensu Go handler definition:
+
+**slack-handler.json**
 
 ```json
 {
@@ -38,14 +92,40 @@ slack-handler.json
         "timeout": 30,
         "filters": [
             "is_incident"
-        ]
+        ],
+        "runtime_assets": ["sensu-slack-handler_linux_amd64"]
     }
 }
 ```
 
 `sensuctl create -f slack-handler.json`
 
+**sensu-slack-handler.yml**
+
+```yaml
+---
+api_version: core/v2
+type: Handler
+metadata:
+  namespace: default
+  name: slack
+spec:
+  type: pipe
+  command: 'sensu-slack-handler --channel ''#general'' --timeout 20 --username ''sensu'' '
+  env_vars:
+  - SLACK_WEBHOOK_URL=https://www.webhook-url-for-slack.com
+  timeout: 30
+  filters:
+  - is_incident
+  runtime_assets:
+  - sensu-slack-handler_linux_amd64
+```
+
+`sensuctl create -f slack-handler.yml`
+
 Example Sensu Go check definition:
+
+**check-dummy-app-healthz.json**
 
 ```json
 {
@@ -69,6 +149,25 @@ Example Sensu Go check definition:
 }
 ```
 
+**check-dummy-app-healthz.yml**
+
+```yaml
+---
+api_version: core/v2
+type: CheckConfig
+metadata:
+  namespace: default
+  name: dummy-app-healthz
+spec:
+  command: check-http -u http://localhost:8080/healthz
+  subscriptions:
+  - dummy
+  publish: true
+  interval: 10
+  handlers:
+  - slack
+```
+
 **Security Note:** The Slack webhook url is treated as a security sensitive configuration option in this example and is loaded into the handler config as an env_var instead of as a command argument. Command arguments are commonly readable from the process table by other unprivaledged users on a system (ex: `ps` and `top` commands), so it's a better practise to read in sensitive information via environment variables or configuration files on disk. The `--webhook-url` flag is provided as an override for testing purposes.
 
 ## Usage examples
@@ -88,6 +187,16 @@ Flags:
   -t, --timeout int          The amount of seconds to wait before terminating the handler (default 10)
   -u, --username string      The username that messages will be sent as (default "sensu")
   -w, --webhook-url string   The webhook url to send messages to, defaults to value of SLACK_WEBHOOK_URL env variable
+```
+
+## Installing from source and contributing
+
+The preferred way of installing and deploying this plugin is to use it as an [asset]. If you would like to compile and install the plugin from source, or contribute to it, download the latest version of the sensu-slack-handler from [releases][2],
+or create an executable script from this source.
+
+From the local path of the slack-handler repository:
+```
+go build -o /usr/local/bin/sensu-slack-handler main.go
 ```
 
 [1]: https://docs.sensu.io/sensu-go/5.0/reference/handlers/#how-do-sensu-handlers-work

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Assets are the best way to make use of this handler. If you're not using an asse
 
 `sensuctl asset add sensu/sensu-slack-handler`
 
-If you're using an earlier version of sensuctl, you can find the asset on the [Bonsai Asset Index](https://bonsai.sensu.io/assets/sensu/sensu-slack-handler).
+If you're using an earlier version of sensuctl, you can download the asset definition from [this project's Bonsai Asset Index page](https://bonsai.sensu.io/assets/sensu/sensu-slack-handler).
 
 #### Example Sensu Go handler definition:
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Bonsai Asset Badge](https://img.shields.io/badge/Sensu%20Slack%20Handler-Download%20Me-brightgreen.svg?colorB=89C967&logo=sensu)](https://bonsai.sensu.io/assets/sensu/sensu-slack-handler) [![Build Status](https://travis-ci.org/sensu/sensu-slack-handler.svg?branch=master)](https://travis-ci.org/sensu/sensu-slack-handler)
+
 # Sensu Go Slack Handler
 
 The Sensu Slack handler is a [Sensu Event Handler][1] that sends event data to

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you're using an earlier version of sensuctl, you can download the asset defin
         "filters": [
             "is_incident"
         ],
-        "runtime_assets": ["sensu-slack-handler_linux_amd64"]
+        "runtime_assets": ["sensu-slack-handler"]
     }
 }
 ```
@@ -63,7 +63,7 @@ spec:
   filters:
   - is_incident
   runtime_assets:
-  - sensu-slack-handler_linux_amd64
+  - sensu-slack-handler
 ```
 
 `sensuctl create -f slack-handler.yml`

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ a configured Slack channel.
 
 Assets are the best way to make use of this handler. If you're not using an asset, please consider doing so! If you're using sensuctl 5.13 or later, you can use the following command to add the asset: 
 
-`sensuctl asset add sensu/sensu-slack-handler:1.0.3`
+`sensuctl asset add sensu/sensu-slack-handler`
 
 If you're using an earlier version of sensuctl, you can find the asset on the [Bonsai Asset Index](https://bonsai.sensu.io/assets/sensu/sensu-slack-handler).
 

--- a/README.md
+++ b/README.md
@@ -203,3 +203,4 @@ go build -o /usr/local/bin/sensu-slack-handler main.go
 
 [1]: https://docs.sensu.io/sensu-go/5.0/reference/handlers/#how-do-sensu-handlers-work
 [2]: https://github.com/sensu/sensu-slack-handler/releases
+[3]: #asset-registration


### PR DESCRIPTION
The current readme's first instructions to users is to install the plugin by building the plugin from source. This goes against our recommended practice of using Bonsai for downloading/installing plugins. The changes here attempt to be a bit more prescriptive and tell users to install the asset from Bonsai, as well as provide some example json/yml bits for configuration/installation