### PR TITLE
Add suppoort for expanding newlines (\n) in description template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- Support for newline (\n) expansion in description template
+
 ## [1.3.1] - 2020-03-30
 
 ### Changed

--- a/main.go
+++ b/main.go
@@ -174,6 +174,7 @@ func messageAttachment(event *corev2.Event) *slack.Attachment {
 	if err != nil {
 		fmt.Errorf("Error processing template: %s", err)
 	}
+	description = strings.Replace(description, `\n`, "\n", -1)
 	attachment := &slack.Attachment{
 		Title:    "Description",
 		Text:     description,


### PR DESCRIPTION
Addresses one item mentioned in a comment for #22 