### PR TITLE
feature: enable FreeBSD builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,7 @@ builds:
       - darwin
       - linux
       - windows
+      - freebsd
     goarch:
       - amd64
       - 386
@@ -28,6 +29,9 @@ builds:
       - linux_arm64
       - windows_386
       - windows_amd64
+      - freebsd_386
+      - freebsd_arm64
+      - freebsd_amd64
 
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_sha512-checksums.txt"


### PR DESCRIPTION
this PR add FreeBSD to release build.

```
> goreleaser build 

   • building...      
   • loading config file       file=.goreleaser.yml
   • running before hooks
   • loading environment variables
   • getting and validating git state
      • releasing 1.3.3, commit 752746ddf3d782dab474b95e2793eb20faaec4a1
   • parsing tag      
   • setting defaults 
      • snapshotting     
      • github/gitlab/gitea releases
      • project name     
      • building binaries
      • creating source archive
      • archives         
      • linux packages   
      • snapcraft packages
      • calculating checksums
      • signing artifacts
      • docker images    
      • artifactory      
      • blobs            
      • homebrew tap formula
      • scoop manifests  
   • snapshotting     
      • pipe skipped              error=not a snapshot
   • checking ./dist  
   • writing effective config file
      • writing                   config=dist/config.yaml
   • generating changelog
      • writing                   changelog=dist/CHANGELOG.md
   • building binaries
      • building                  binary=/home/trombik/github/trombik/sensu-slack-handler/dist/sensu-slack-handler_freebsd_amd64/bin/sensu-slack-handler
      • building                  binary=/home/trombik/github/trombik/sensu-slack-handler/dist/sensu-slack-handler_linux_386/bin/sensu-slack-handler
      • building                  binary=/home/trombik/github/trombik/sensu-slack-handler/dist/sensu-slack-handler_linux_arm_5/bin/sensu-slack-handler
      • building                  binary=/home/trombik/github/trombik/sensu-slack-handler/dist/sensu-slack-handler_darwin_amd64/bin/sensu-slack-handler
      • building                  binary=/home/trombik/github/trombik/sensu-slack-handler/dist/sensu-slack-handler_windows_386/bin/sensu-slack-handler.exe
      • building                  binary=/home/trombik/github/trombik/sensu-slack-handler/dist/sensu-slack-handler_linux_arm_6/bin/sensu-slack-handler
      • building                  binary=/home/trombik/github/trombik/sensu-slack-handler/dist/sensu-slack-handler_linux_arm_7/bin/sensu-slack-handler
      • building                  binary=/home/trombik/github/trombik/sensu-slack-handler/dist/sensu-slack-handler_linux_arm64/bin/sensu-slack-handler
      • building                  binary=/home/trombik/github/trombik/sensu-slack-handler/dist/sensu-slack-handler_linux_amd64/bin/sensu-slack-handler
      • building                  binary=/home/trombik/github/trombik/sensu-slack-handler/dist/sensu-slack-handler_freebsd_386/bin/sensu-slack-handler
      • building                  binary=/home/trombik/github/trombik/sensu-slack-handler/dist/sensu-slack-handler_windows_amd64/bin/sensu-slack-handler.exe
      • building                  binary=/home/trombik/github/trombik/sensu-slack-handler/dist/sensu-slack-handler_freebsd_arm64/bin/sensu-slack-handler
   • build succeeded after 259.27s
```