### PR TITLE
Explain annotation override

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,15 +90,11 @@ as for `description-template` as a check annotation requires that you place the
 desired template as a [golang string literal][11] (enlcosed in backticks)
 within another template definition.  This does not apply to entity annotations.
 
-set a backend `SLACK_CHANNEL` environment variable to the `#monitoring-alerts` channel. 
-
-Runtime env_vars defined for a slack handler's definition in backend lose to event's entity annotations if latter are present.
+Per-entity and per-check arguments set in entity and check annotations will override any arguments set in the handler command with flags or in backend runtime environment variables.
 
 #### Examples
 
-If you use entity or check annotations to set arguments for the Sensu Slack Handler, the values in the annotations will override any values you set in the handler command or backend runtime environment variables.
-
-For example, imagine you configure the a Slack handler whose command sets the `--channel` flag to `#monitoring`.
+Imagine you configure the a Slack handler whose command sets the `--channel` flag to `#monitoring`.
 Suppose that for one particular entity, you want to use the Slack handler, but you want the entity's incidents to go to the `#special-alerts` Slack channel.
 You update the entity to include the following annotation:
 

--- a/README.md
+++ b/README.md
@@ -90,16 +90,26 @@ as for `description-template` as a check annotation requires that you place the
 desired template as a [golang string literal][11] (enlcosed in backticks)
 within another template definition.  This does not apply to entity annotations.
 
+set a backend `SLACK_CHANNEL` environment variable to the `#monitoring-alerts` channel. 
+
+Runtime env_vars defined for a slack handler's definition in backend lose to event's entity annotations if latter are present.
+
 #### Examples
 
-To customize the channel for a given entity, you could use the following
-sensu-agent configuration snippet:
+If you use entity or check annotations to set arguments for the Sensu Slack Handler, the values in the annotations will override any values you set in the handler command or backend runtime environment variables.
+
+For example, imagine you configure the a Slack handler whose command sets the `--channel` flag to `#monitoring`.
+Suppose that for one particular entity, you want to use the Slack handler, but you want the entity's incidents to go to the `#special-alerts` Slack channel.
+You update the entity to include the following annotation:
 
 ```yml
 # /etc/sensu/agent.yml example
 annotations:
-  sensu.io/plugins/slack/config/channel: '#monitoring'
+  sensu.io/plugins/slack/config/channel: '#special-alerts'
 ```
+
+For this one entity, the Slack handler will send alerts to the `#special-alerts` channel (the entity annotation overrides the handler command flag).
+For all other entites, the Slack handler will send alerts to the `#monitoring` channel as configured in the handler command flag.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,10 @@ Per-entity and per-check arguments set in entity and check annotations will over
 
 #### Examples
 
-Imagine you configure the a Slack handler whose command sets the `--channel` flag to `#monitoring`.
-Suppose that for one particular entity, you want to use the Slack handler, but you want the entity's incidents to go to the `#special-alerts` Slack channel.
-You update the entity to include the following annotation:
+Suppose that you configure the a Slack handler whose command sets the `--channel` flag to `#monitoring`.
+For one particular entity, you want to use the Slack handler, but you want the entity's incidents to go to the `#special-alerts` Slack channel.
+
+Update the entity definition to include an annotation that specifies the `#special-alerts` channel:
 
 ```yml
 # /etc/sensu/agent.yml example


### PR DESCRIPTION
A Sensu Slack Handler plugin user reported some confusion about the precedence of arguments set in per-entity (or per-check) annotations.

The user said `Runtime env_vars defined for a slack handler's definition in backend lose to event's entity annotations if latter are present.`

I believe the user is referring to the plugin readme rather than env var documentation in the Sensu docs. Read the [user ticket ](https://secure.helpscout.net/conversation/1818609343/28580/)for more context.