### PR TITLE
new argument to alert the channel on critical events

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,4 +13,4 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Run golangci-lint
-      uses: actions-contrib/golangci-lint@v1
+      uses: actions-contrib/golangci-lint@@v1.1.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,4 +13,4 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Run golangci-lint
-      uses: actions-contrib/golangci-lint@@v1.1.0
+      uses: matoous/golangci-lint-action@v1.23.3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Run golangci-lint
-      uses: matoous/golangci-lint-action@v1.23.3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.17
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Available Commands:
   version     Print the version number of this plugin
 
 Flags:
+  -a, --alert-on-critical             The Slack notification will alert the channel with @channel
   -c, --channel string                The channel to post messages to (default "#general")
   -t, --description-template string   The Slack notification output template, in Golang text/template format (default "{{ .Check.Output }}")
   -h, --help                          help for sensu-slack-handler
@@ -53,6 +54,7 @@ Flags:
 |--username             |SLACK_USERNAME             |
 |--icon-url             |SLACK_ICON_URL             |
 |--description-template |SLACK_DESCRIPTION_TEMPLATE |
+|--alert-on-critical    |SENSU_SLACK_ALERT_CRITICAL |
 
 
 **Security Note:** Care should be taken to not expose the webhook URL for this handler by specifying it

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Flags:
 |--username             |SLACK_USERNAME             |
 |--icon-url             |SLACK_ICON_URL             |
 |--description-template |SLACK_DESCRIPTION_TEMPLATE |
-|--alert-on-critical    |SENSU_SLACK_ALERT_CRITICAL |
+|--alert-on-critical    |SLACK_ALERT_ON_CRITICAL    |
 
 
 **Security Note:** Care should be taken to not expose the webhook URL for this handler by specifying it

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/bluele/slack"
@@ -95,7 +94,7 @@ var (
 		},
 		{
 			Path:      alertCritical,
-			Env:       "SLACK_ALERT_CRITICAL",
+			Env:       "SLACK_ALERT_ON_CRITICAL",
 			Argument:  alertCritical,
 			Shorthand: "a",
 			Default:   defaultAlert,
@@ -123,9 +122,6 @@ func checkArgs(_ *corev2.Event) error {
 	}
 	if icon := os.Getenv("SENSU_SLACK_ICON_URL"); icon != "" && config.slackIconURL == defaultIconURL {
 		config.slackIconURL = icon
-	}
-	if alert := os.Getenv("SENSU_SLACK_ALERT_CRITICAL"); alertCritical != "" && !config.slackAlertCritical {
-		config.slackAlertCritical, _ = strconv.ParseBool(alert)
 	}
 
 	if len(config.slackwebHookURL) == 0 {

--- a/main.go
+++ b/main.go
@@ -124,7 +124,7 @@ func checkArgs(_ *corev2.Event) error {
 	if icon := os.Getenv("SENSU_SLACK_ICON_URL"); icon != "" && config.slackIconURL == defaultIconURL {
 		config.slackIconURL = icon
 	}
-	if alert := os.Getenv("SENSU_SLACK_ALERT_CRITICAL"); alertCritical != "" && config.slackAlertCritical == defaultAlert {
+	if alert := os.Getenv("SENSU_SLACK_ALERT_CRITICAL"); alertCritical != "" && !config.slackAlertCritical {
 		config.slackAlertCritical, _ = strconv.ParseBool(alert)
 	}
 
@@ -180,7 +180,7 @@ func messageStatus(event *corev2.Event) string {
 	case 0:
 		return "Resolved"
 	case 2:
-		if config.slackAlertCritical == true {
+		if config.slackAlertCritical {
 			return "<!channel> Critical"
 		} else {
 			return "Critical"


### PR DESCRIPTION
Signed-off-by: sabbene <sabbene@0hy.es>

Hello,

This pull request is to introduce a new feature.  I have added the argument --alert-on-critical to sensu-slack-handler.  The purpose of this new argument is to give people the option to have @channel added to the alert sent to slack.

Currently we are appending @channel to the output of our checks to get slack notifications for critical events, but this looks silly for other alerting mechanisms.  For example getting an email with @channel in the body.

Here is a screen shot of how the alerts look with the new argument:

![image](https://user-images.githubusercontent.com/11637137/168186581-fff7c932-e601-470d-be6c-4fc0ee2ccc95.png)

 I also set up the github actions for this repo in my fork, and noticed that the Lint action was no longer working.  I updated the 'Run golangci-lint' step to use the latest release of the tool (v1.23.3).

Please let me know if there are any questions or concerns.