### PR TITLE
Indicate Unknown status when status code is 3 or higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- Indicate Unknown status when status code is 3 or higher
+
 ## [1.5.0] - 2021-03-022
 
 ### Changed

--- a/main.go
+++ b/main.go
@@ -164,10 +164,12 @@ func messageColor(event *corev2.Event) string {
 	switch event.Check.Status {
 	case 0:
 		return "good"
+	case 1:
+		return "warning"
 	case 2:
 		return "danger"
 	default:
-		return "warning"
+		return "#000000"
 	}
 }
 
@@ -175,6 +177,8 @@ func messageStatus(event *corev2.Event) string {
 	switch event.Check.Status {
 	case 0:
 		return "Resolved"
+	case 1:
+		return "Warning"
 	case 2:
 		if config.slackAlertCritical {
 			return "<!channel> Critical"
@@ -182,7 +186,7 @@ func messageStatus(event *corev2.Event) string {
 			return "Critical"
 		}
 	default:
-		return "Warning"
+		return "Unknown"
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -84,6 +84,10 @@ func TestMessageColor(t *testing.T) {
 	event.Check.Status = 2
 	color = messageColor(event)
 	assert.Equal("danger", color)
+
+	event.Check.Status = 3
+	color = messageColor(event)
+	assert.Equal("#000000", color)
 }
 
 func TestMessageStatus(t *testing.T) {
@@ -101,6 +105,10 @@ func TestMessageStatus(t *testing.T) {
 	event.Check.Status = 2
 	status = messageStatus(event)
 	assert.Equal("Critical", status)
+
+	event.Check.Status = 3
+	status = messageStatus(event)
+	assert.Equal("Unknown", status)
 }
 
 func TestSendMessage(t *testing.T) {


### PR DESCRIPTION
In the current implementation, events with a status code of 3 or higher (Unknown) are notified as Warnings.
This PR clearly indicates that it is Unknown when notifying an Event with 3 or higher status codes.
